### PR TITLE
feat(rest): shared REST v2 client + integration tests

### DIFF
--- a/src/client/rest-client.ts
+++ b/src/client/rest-client.ts
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { z } from 'zod';
+
+export const RestClientOptions = z.object({
+  apiKey: z.string().min(1),
+  region: z.enum(['US', 'EU']).default('US'),
+});
+export type RestClientOptions = z.infer<typeof RestClientOptions>;
+
+export type Region = 'US' | 'EU';
+
+function baseUrlForRegion(region: Region): string {
+  return region === 'EU' ? 'https://api.eu.newrelic.com/v2' : 'https://api.newrelic.com/v2';
+}
+
+function serializeQuery(params: Record<string, unknown> | undefined): string {
+  if (!params) return '';
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      // arrays as repeated params: names[]=a&names[]=b
+      value.forEach((v) => query.append(`${key}[]`, String(v)));
+    } else {
+      query.set(key, String(value));
+    }
+  }
+  const qs = query.toString();
+  return qs ? `?${qs}` : '';
+}
+
+function parseLinkHeader(linkHeader: string | null): Record<string, string> {
+  if (!linkHeader) return {};
+  const parts = linkHeader.split(',');
+  const links: Record<string, string> = {};
+  for (const part of parts) {
+    const section = part.split(';');
+    if (section.length < 2) continue;
+    const url = section[0].trim().replace(/^<|>$/g, '');
+    const relMatch = section[1].match(/rel="(.*)"/);
+    const rel = relMatch?.[1];
+    if (rel) {
+      links[rel] = url;
+    }
+  }
+  return links;
+}
+
+export interface RestResponse<T> {
+  status: number;
+  data: T;
+  links?: Record<string, string>;
+  url: string;
+}
+
+export class NewRelicRestClient {
+  private readonly apiKey: string;
+  private readonly region: Region;
+
+  constructor(options: RestClientOptions) {
+    this.apiKey = options.apiKey;
+    this.region = options.region;
+  }
+
+  private buildUrl(path: string, query?: Record<string, unknown>): string {
+    const base = baseUrlForRegion(this.region);
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    const qs = serializeQuery(query);
+    return `${base}${normalizedPath}.json${qs}`;
+  }
+
+  async get<T>(path: string, query?: Record<string, unknown>): Promise<RestResponse<T>> {
+    const url = this.buildUrl(path, query);
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': this.apiKey,
+      },
+    });
+    const links = parseLinkHeader(response.headers.get('link'));
+    const data = (await response.json()) as T;
+    if (!response.ok) {
+      throw new Error(`REST API error: ${response.status} ${response.statusText}`);
+    }
+    return { status: response.status, data, links, url };
+  }
+
+  async post<T>(path: string, body: unknown): Promise<RestResponse<T>> {
+    const url = this.buildUrl(path);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': this.apiKey,
+      },
+      body: JSON.stringify(body),
+    });
+    const links = parseLinkHeader(response.headers.get('link'));
+    const data = (await response.json()) as T;
+    if (!response.ok) {
+      throw new Error(`REST API error: ${response.status} ${response.statusText}`);
+    }
+    return { status: response.status, data, links, url };
+  }
+
+  async delete<T>(path: string): Promise<RestResponse<T>> {
+    const url = this.buildUrl(path);
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': this.apiKey,
+      },
+    });
+    const links = parseLinkHeader(response.headers.get('link'));
+    const data = (await response.json()) as T;
+    if (!response.ok) {
+      throw new Error(`REST API error: ${response.status} ${response.statusText}`);
+    }
+    return { status: response.status, data, links, url };
+  }
+}
+
+export const __test__ = { serializeQuery, parseLinkHeader, baseUrlForRegion };

--- a/test/client/rest-client/rest-client.test.ts
+++ b/test/client/rest-client/rest-client.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { __test__, NewRelicRestClient } from '../../../src/client/rest-client';
+
+describe('rest-client helpers', () => {
+  it('baseUrlForRegion', () => {
+    expect(__test__.baseUrlForRegion('US')).toContain('api.newrelic.com');
+    expect(__test__.baseUrlForRegion('EU')).toContain('api.eu.newrelic.com');
+  });
+
+  it('serializeQuery arrays', () => {
+    const qs = __test__.serializeQuery({ names: ['A', 'B'], single: 'x' });
+    expect(qs).toContain('names%5B%5D=A');
+    expect(qs).toContain('names%5B%5D=B');
+    expect(qs).toContain('single=x');
+  });
+
+  it('parseLinkHeader', () => {
+    const header =
+      '<https://api.newrelic.com/v2/apps.json?page=2>; rel="next", <https://api.newrelic.com/v2/apps.json?page=10>; rel="last"';
+    const links = __test__.parseLinkHeader(header);
+    expect(links.next).toBeDefined();
+    expect(links.last).toBeDefined();
+  });
+});
+
+describe('NewRelicRestClient url building', () => {
+  it('appends .json and query correctly', () => {
+    const client = new NewRelicRestClient({ apiKey: 'k', region: 'US' });
+    // @ts-expect-error private method access not allowed; build via public get
+    const url = client['buildUrl']('/applications', { page: 2 });
+    expect(url).toContain('/applications.json');
+    expect(url).toContain('page=2');
+  });
+});

--- a/test/integration/rest-client.integration.test.ts
+++ b/test/integration/rest-client.integration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { NewRelicRestClient } from '../../src/client/rest-client';
+
+// Integration tests require real API keys. Each suite is skipped if
+// its corresponding env var is not present.
+// US: NEW_RELIC_API_KEY or NEW_RELIC_API_KEY_US
+// EU: NEW_RELIC_API_KEY_EU (EU-region account key required)
+
+const usKey = process.env.NEW_RELIC_API_KEY || process.env.NEW_RELIC_API_KEY_US;
+const euKey = process.env.NEW_RELIC_API_KEY_EU;
+
+const describeUS = usKey ? describe : describe.skip;
+const describeEU = euKey ? describe : describe.skip;
+
+describeUS('REST v2 integration (US region)', () => {
+  it('GET /applications returns 200', async () => {
+    const client = new NewRelicRestClient({ apiKey: usKey as string, region: 'US' });
+    const res = await client.get<Record<string, unknown>>('/applications');
+    expect(res.status).toBe(200);
+    expect(typeof res.data).toBe('object');
+  });
+});
+
+describeEU('REST v2 integration (EU region)', () => {
+  it('GET /applications returns 200', async () => {
+    const client = new NewRelicRestClient({ apiKey: euKey as string, region: 'EU' });
+    const res = await client.get<Record<string, unknown>>('/applications');
+    expect(res.status).toBe(200);
+    expect(typeof res.data).toBe('object');
+  });
+});


### PR DESCRIPTION
Closes #2

Implements the shared REST client per `doc/rest-tools-stories/00-shared-rest-client.md`:
- Region-aware base URL (US/EU)
- Auth headers (`Api-Key`)
- RFC 5988 Link header parsing
- Query serialization helpers (arrays -> names[])
- GET/POST/DELETE helpers

Adds tests:
- Unit tests: helper functions and URL building
- Integration tests: GET /applications for US (NEW_RELIC_API_KEY or NEW_RELIC_API_KEY_US) and EU (NEW_RELIC_API_KEY_EU). Each auto-skips if env not set.

No breaking changes to existing tools.
