### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - Planned: Minor bug fixes and DX improvements
 
+## [2.0.0] - 2025-08-09
+
+### Added
+
+- New REST v2 client (`src/client/rest-client.ts`) with region-aware base URL, auth headers, query serialization, and RFC 5988 Link parsing.
+- REST tools:
+  - Deployments: create, list (auto-paginate), delete with confirm.
+  - APM applications: list with filters and auto-pagination.
+  - Metrics: list metric names for host; get metric data for host; list application hosts (auto-paginate).
+  - Alerts (REST): list policies; list incidents with client-side filtering for open/priority.
+- Unit tests for all REST tools and helpers; integration tests for REST client against US/EU endpoints (conditionally skipped without creds).
+- Documentation: consolidated under `docs/` with a pinned Swagger guidance and per-tool stories.
+
+### Changed
+
+- Server wiring to register new REST tools alongside existing NerdGraph tools.
+
+### Notes
+
+- Acknowledge incident via REST is not supported; continue using NerdGraph (`aiIssuesAckIssue`).
+
 ## [1.1.1] - 2025-08-08
 
 ### Changed
@@ -61,7 +82,8 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - Ignored `.cursor/` directory and removed committed files to avoid secret scanning violations.
 
-[Unreleased]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/cloudbring/newrelic-mcp/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.2...v2.0.0
 [1.1.2]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/cloudbring/newrelic-mcp/releases/tag/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - Server wiring to register new REST tools alongside existing NerdGraph tools.
 
+### Breaking changes
+
+- No breaking changes. Existing tool names and behaviors remain intact; this release adds new REST tools alongside the current NerdGraph tools.
+
 ### Notes
 
 - Acknowledge incident via REST is not supported; continue using NerdGraph (`aiIssuesAckIssue`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-mcp",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Model Context Protocol server for New Relic observability platform integration",
   "main": "dist/server.js",
   "bin": {


### PR DESCRIPTION
Release v2.0.0 – REST v2 client and tools

Highlights
- New REST v2 client (region-aware base URL, `Api-Key` auth, query serialization, RFC 5988 Link parsing)
- REST tools:
  - Deployments: create, list (auto-paginate), delete with confirm
  - APM applications: list with filters and auto-pagination
  - Metrics: list metric names for host; get metric data for host; list application hosts (auto-paginate)
  - Alerts (REST): list policies; list incidents with client-side filtering for open/priority
- Unit tests + integration tests (US/EU, skipped without creds)
- Documentation consolidated under `docs/` with per-tool stories

Notes
- Incident acknowledgment is NerdGraph-only; use `aiIssuesAckIssue`

Changelog excerpt
- See `CHANGELOG.md` section [2.0.0] for details

After merge
- CI will run. On tag v2.0.0 (already pushed), the publish workflow should release to npm if configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to reflect the new 2.0.0 release, highlighting major new REST v2 client features and tools.
  * Clarified documentation structure and added notes on incident acknowledgment support.

* **Chores**
  * Updated the application version to 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->