### PR TITLE
Chore: Smithery build metadata (smithery.yaml) and docs/tests alignment

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,4 +1,8 @@
 runtime: "typescript"
+entry: "src/server.ts"
+start:
+  command: ["node", "dist/server.js"]
+  port: 8000
 env:
   NODE_ENV: "production"
 


### PR DESCRIPTION
Add explicit Smithery build metadata (entry/start) and align docs/tests with tool discovery behavior.

- Add `entry` and `start.command` to `smithery.yaml` so the Smithery CLI can find the entry point and start command.
- Update README with Smithery CLI guidance and prefer TypeScript runtime.
- Align server env-validation tests to allow construction without NEW_RELIC_API_KEY (tool-discovery).

CI: lint + tests pass locally.
