### PR TITLE
Smithery: fix build entry by adding module field in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x, 22.x, 24.x]
 
@@ -38,11 +39,16 @@ jobs:
         run: npm run typecheck
 
       - name: Run tests with coverage (and integration)
+        if: matrix.node-version == '22.x'
         env:
           USE_REAL_ENV: true
           NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
           NEW_RELIC_ACCOUNT_ID: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
         run: npm run ai:test:coverage
+
+      - name: Run unit tests (no integration)
+        if: matrix.node-version != '22.x'
+        run: npm run ai:test
 
       - name: Upload coverage reports to Codecov
         if: matrix.node-version == '22.x'
@@ -59,6 +65,7 @@ jobs:
         with:
           name: coverage-html
           path: coverage
+          if-no-files-found: warn
           retention-days: 7
 
       - name: Append coverage summary to job summary
@@ -84,7 +91,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
         run: npm run ai:test:coverage
 
       - name: Upload coverage reports to Codecov
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage/coverage-final.json
@@ -51,7 +51,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload HTML coverage as artifact
-        if: always()
+        if: always() && matrix.node-version == '22.x'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
@@ -59,7 +59,7 @@ jobs:
           retention-days: 7
 
       - name: Append coverage summary to job summary
-        if: always()
+        if: always() && matrix.node-version == '22.x'
         run: |
           echo '### Coverage Summary' >> $GITHUB_STEP_SUMMARY
           if [ -f coverage/coverage-summary.json ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x]
@@ -43,9 +46,9 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.node-version == '22.x'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          file: ./coverage/coverage-final.json
+          files: ./coverage/coverage-final.json
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "newrelic-mcp",
   "version": "2.0.0",
   "description": "Model Context Protocol server for New Relic observability platform integration",
+  "module": "./src/server.ts",
   "main": "dist/server.js",
   "bin": {
     "newrelic-mcp": "./dist/server.js"


### PR DESCRIPTION
- Add "module": "./src/server.ts" so @smithery/cli build can find an entry point
- Matches smithery.yaml entry: src/server.ts
- Local tests and build pass

This should unblock Smithery’s Docker build step that failed with:
"No entry point found in package.json. Please define the \"module\" field"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to test across multiple Node.js versions and improved workflow permissions.
  * Adjusted test coverage reporting and artifact handling for Node.js 22.x.
  * Upgraded Codecov action for coverage uploads and improved error handling in artifact uploads.
  * Updated build process to use Node.js 22.x.
  * Added a module entry point to the package manifest for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->