### PR TITLE
Update installation command for New Relic MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npx @smithery/cli inspect @cloudbring/newrelic-mcp
 npx @smithery/cli run @cloudbring/newrelic-mcp --config '{"NEW_RELIC_API_KEY":"...","NEW_RELIC_ACCOUNT_ID":"..."}'
 
 # Install into a specific client
-npx @smithery/cli install @cloudbring/newrelic-mcp --client claude
+npx @smithery/cli install newrelic-mcp --client claude
 
 # Open playground
 npx @smithery/cli playground --port 3001

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install or deploy via Smithery, see the official docs: [Deployments](https://
 To install New Relic MCP for Claude Desktop automatically via [Smithery](https://smithery.ai/mcp/newrelic-mcp):
 
 ```bash
-npx @smithery/cli install newrelic-mcp --client claude
+npx @smithery/cli install @cloudbring/newrelic-mcp --client claude
 ```
 
 ### Smithery CLI (recommended)
@@ -54,7 +54,7 @@ npx @smithery/cli inspect @cloudbring/newrelic-mcp
 npx @smithery/cli run @cloudbring/newrelic-mcp --config '{"NEW_RELIC_API_KEY":"...","NEW_RELIC_ACCOUNT_ID":"..."}'
 
 # Install into a specific client
-npx @smithery/cli install newrelic-mcp --client claude
+npx @smithery/cli install @cloudbring/newrelic-mcp --client claude
 
 # Open playground
 npx @smithery/cli playground --port 3001


### PR DESCRIPTION
### Summary

I've received the following error while using the previous install command:
```
✖ Failed to install newrelic-mcp
Error: API error occurred: {"error":"Server not found","request$":{},"response$":{},"body$":"{\"error\":\"Server not found\"}"}
```

Matching the server to https://smithery.ai/server/@cloudbring/newrelic-mcp

### Type of change

- [x] docs: Documentation update

### Checklist

- [x] Tests added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation examples to use the scoped package name (@cloudbring/newrelic-mcp) instead of the previous package naming, ensuring install instructions match the current distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->