### PR TITLE
feat: Add regional support for EU/US regions with default fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - Planned: Minor bug fixes and DX improvements
 
+## [2.0.1] - TBD
+
+### Added
+
+- Regional support for NerdGraph API endpoints (US and EU)
+- `NEW_RELIC_REGION` environment variable to configure data center region
+- Region-aware URL selection for all NerdGraph operations
+
+### Changed
+
+- NerdGraph client now dynamically selects endpoint based on `NEW_RELIC_REGION` env var
+- Default region is US if not specified
+- Updated `smithery.json` to document `NEW_RELIC_REGION` environment variable
+- Updated README with examples for both US and EU regions
+- Added test utilities: added region helpers into shared `test/utils/region-helpers.ts`
+
+### Fixed
+
+- Fixed NerdGraph API calls to work correctly for EU region accounts
+- All NerdGraph tools now respect regional configuration
+
 ## [2.0.0] - 2025-08-09
 
 ### Added
@@ -86,7 +107,8 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 - Ignored `.cursor/` directory and removed committed files to avoid secret scanning violations.
 
-[Unreleased]: https://github.com/cloudbring/newrelic-mcp/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/cloudbring/newrelic-mcp/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/cloudbring/newrelic-mcp/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.2...v2.0.0
 [1.1.2]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/cloudbring/newrelic-mcp/compare/v1.1.0...v1.1.1

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npx @smithery/cli build src/server.ts --out .smithery/index.cjs --transport shtt
 npx @smithery/cli inspect @cloudbring/newrelic-mcp
 
 # Run with config (env via JSON)
-npx @smithery/cli run @cloudbring/newrelic-mcp --config '{"NEW_RELIC_API_KEY":"...","NEW_RELIC_ACCOUNT_ID":"..."}'
+npx @smithery/cli run @cloudbring/newrelic-mcp --config '{"NEW_RELIC_API_KEY":"...","NEW_RELIC_ACCOUNT_ID":"...","NEW_RELIC_REGION":"US"}'
 
 # Install into a specific client
 npx @smithery/cli install newrelic-mcp --client claude
@@ -86,7 +86,8 @@ Add to your Claude Desktop configuration file:
       ],
       "env": {
         "NEW_RELIC_API_KEY": "your-api-key-here",
-        "NEW_RELIC_ACCOUNT_ID": "your-account-id"
+        "NEW_RELIC_ACCOUNT_ID": "your-account-id",
+        "NEW_RELIC_REGION": "US"
       }
     }
   }
@@ -109,7 +110,8 @@ Add to your Cline settings in VS Code:
       "args": ["-y", "newrelic-mcp"],
       "env": {
         "NEW_RELIC_API_KEY": "your-api-key-here",
-        "NEW_RELIC_ACCOUNT_ID": "your-account-id"
+        "NEW_RELIC_ACCOUNT_ID": "your-account-id",
+        "NEW_RELIC_REGION": "US"
       }
     }
   ]
@@ -157,7 +159,8 @@ Add to your Windsurf Cascade configuration:
       "args": ["-y", "newrelic-mcp"],
       "env": {
         "NEW_RELIC_API_KEY": "your-api-key-here",
-        "NEW_RELIC_ACCOUNT_ID": "your-account-id"
+        "NEW_RELIC_ACCOUNT_ID": "your-account-id",
+        "NEW_RELIC_REGION": "US"
       }
     }
   }
@@ -193,7 +196,8 @@ npm run build
       "args": ["/path/to/newrelic-mcp/dist/server.js"],
       "env": {
         "NEW_RELIC_API_KEY": "your-api-key-here",
-        "NEW_RELIC_ACCOUNT_ID": "your-account-id"
+        "NEW_RELIC_ACCOUNT_ID": "your-account-id",
+        "NEW_RELIC_REGION": "US"
       }
     }
   }
@@ -208,6 +212,7 @@ npm run build
 
 - `NEW_RELIC_API_KEY` - Your New Relic User API Key (required)
 - `NEW_RELIC_ACCOUNT_ID` - Your New Relic Account ID (optional, can be provided per tool call)
+- `NEW_RELIC_REGION` - New Relic data center region: `US` (default) or `EU` (optional)
 
 ### Getting Your New Relic Credentials
 
@@ -219,6 +224,11 @@ npm run build
 2. **Account ID**:
    - Find your Account ID in the URL when logged into New Relic
    - Or navigate to **Administration** → **Access management** → **Accounts**
+
+3. **Region**:
+   - Set `NEW_RELIC_REGION=US` for US data center (default)
+   - Set `NEW_RELIC_REGION=EU` for EU data center
+   - If not specified, defaults to `US`
 
 For detailed setup instructions, see [docs/new-relic-setup.md](docs/new-relic-setup.md).
 
@@ -304,8 +314,17 @@ If you're having trouble connecting:
 
 1. Verify your API key is valid:
 
+   For US region:
    ```bash
    curl -X POST https://api.newrelic.com/graphql \
+     -H 'Content-Type: application/json' \
+     -H 'API-Key: YOUR_API_KEY' \
+     -d '{"query":"{ actor { user { email } } }"}'
+   ```
+
+   For EU region:
+   ```bash
+   curl -X POST https://api.eu.newrelic.com/graphql \
      -H 'Content-Type: application/json' \
      -H 'API-Key: YOUR_API_KEY' \
      -d '{"query":"{ actor { user { email } } }"}'
@@ -369,6 +388,7 @@ npm install
 ```bash
 NEW_RELIC_API_KEY=your-api-key-here
 NEW_RELIC_ACCOUNT_ID=your-account-id
+NEW_RELIC_REGION=US
 ```
 
 4. Build the project:

--- a/smithery.json
+++ b/smithery.json
@@ -21,6 +21,10 @@
     "NEW_RELIC_ACCOUNT_ID": {
       "description": "Your New Relic account ID (optional, can be provided per tool call)",
       "required": false
+    },
+    "NEW_RELIC_REGION": {
+      "description": "New Relic data center region: US (default) or EU",
+      "required": false
     }
   },
   "tools": [

--- a/src/client/newrelic-client.ts
+++ b/src/client/newrelic-client.ts
@@ -1,4 +1,14 @@
-const NERDGRAPH_URL = 'https://api.newrelic.com/graphql';
+type Region = 'US' | 'EU';
+
+function getNerdGraphUrl(region: Region): string {
+  return region === 'EU'
+    ? 'https://api.eu.newrelic.com/graphql'
+    : 'https://api.newrelic.com/graphql';
+}
+
+const NERDGRAPH_URL = getNerdGraphUrl(
+  (process.env.NEW_RELIC_REGION?.toUpperCase() as Region) || 'US'
+);
 
 type GraphQLError = { message: string; [key: string]: unknown };
 type GraphQLResponse<T> = { data?: T; errors?: GraphQLError[] };

--- a/src/client/newrelic-client.ts
+++ b/src/client/newrelic-client.ts
@@ -1,5 +1,15 @@
+/**
+ * New Relic data center region identifier.
+ * Supports US (United States) and EU (Europe) regions.
+ */
 type Region = 'US' | 'EU';
 
+/**
+ * Returns the appropriate NerdGraph API endpoint URL based on the specified region.
+ *
+ * @param region - The New Relic data center region ('US' or 'EU')
+ * @returns The NerdGraph GraphQL API endpoint URL for the specified region
+ */
 function getNerdGraphUrl(region: Region): string {
   return region === 'EU'
     ? 'https://api.eu.newrelic.com/graphql'

--- a/test/client/newrelic-client/execute-nerdgraph-query.test.ts
+++ b/test/client/newrelic-client/execute-nerdgraph-query.test.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NewRelicClient } from '../../../src/client/newrelic-client';
+import { getRegionSubdomain } from '../../utils/region-helpers';
 
 const originalFetch = global.fetch;
 
@@ -39,7 +40,7 @@ describe('NewRelicClient.executeNerdGraphQuery', () => {
     const res = result as { data?: { result?: string } };
     expect(res.data?.result).toBe('success');
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.newrelic.com/graphql',
+      `https://api${getRegionSubdomain()}.newrelic.com/graphql`,
       expect.objectContaining({ body: expect.stringContaining('variables') })
     );
   });

--- a/test/client/rest-client/rest-client-requests.test.ts
+++ b/test/client/rest-client/rest-client-requests.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NewRelicRestClient } from '../../../src/client/rest-client';
+import { getRegionSubdomain, getTestRegion } from '../../utils/region-helpers';
 
 describe('NewRelicRestClient requests', () => {
   const apiKey = 'test-api-key';
@@ -15,7 +16,10 @@ describe('NewRelicRestClient requests', () => {
   });
 
   it('get: returns data and parses Link header', async () => {
-    const client = new NewRelicRestClient({ apiKey, region: 'US' });
+    const client = new NewRelicRestClient({
+      apiKey,
+      region: getTestRegion(),
+    });
     const mockJson = { hello: 'world' };
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -24,7 +28,7 @@ describe('NewRelicRestClient requests', () => {
       headers: {
         get: (key: string) =>
           key.toLowerCase() === 'link'
-            ? '<https://api.newrelic.com/v2/x?page=2>; rel="next"'
+            ? `<https://api${getRegionSubdomain()}.newrelic.com/v2/x?page=2>; rel="next"`
             : null,
       },
       json: async () => mockJson,
@@ -62,7 +66,9 @@ describe('NewRelicRestClient requests', () => {
     const res = await client.post<any>('/applications/1/deployments', payload);
     expect(res.status).toBe(201);
     expect(res.data).toEqual(mockJson);
-    expect(res.url).toContain('https://api.eu.newrelic.com/v2/applications/1/deployments.json');
+    expect(res.url).toContain(
+      `https://api${getRegionSubdomain()}.newrelic.com/v2/applications/1/deployments.json`
+    );
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -73,7 +79,10 @@ describe('NewRelicRestClient requests', () => {
   });
 
   it('delete: throws on non-2xx', async () => {
-    const client = new NewRelicRestClient({ apiKey, region: 'US' });
+    const client = new NewRelicRestClient({
+      apiKey,
+      region: getTestRegion(),
+    });
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,

--- a/test/features/common/account-details.test.ts
+++ b/test/features/common/account-details.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NewRelicClient } from '../../../src/client/newrelic-client';
 import { NewRelicMCPServer } from '../../../src/server';
+import { getTestRegion } from '../../utils/region-helpers';
 
 describe('Account Details Feature', () => {
   let _server: NewRelicMCPServer;
@@ -12,7 +13,7 @@ describe('Account Details Feature', () => {
       getAccountDetails: vi.fn().mockResolvedValue({
         accountId: '123456',
         name: 'Test Account',
-        region: 'US',
+        region: getTestRegion(),
         status: 'ACTIVE',
       }),
       executeNerdGraphQuery: vi.fn(),
@@ -31,7 +32,7 @@ describe('Account Details Feature', () => {
       expect(result).toBeDefined();
       expect(result.accountId).toBe('123456');
       expect(result.name).toBe('Test Account');
-      expect(result.region).toBe('US');
+      expect(result.region).toBe(getTestRegion());
       expect(result.status).toBe('ACTIVE');
     });
   });

--- a/test/tools/rest/alerts.test.ts
+++ b/test/tools/rest/alerts.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegionSubdomain } from '../../utils/region-helpers';
 
 const get = vi.fn();
 vi.mock('../../../src/client/rest-client', () => ({
@@ -25,7 +26,9 @@ describe('REST Alerts Tool', () => {
       .mockResolvedValueOnce({
         status: 200,
         data: [{ id: 1, priority: 'HIGH', closed_at: 0 }],
-        links: { next: 'https://api.newrelic.com/v2/alerts_incidents.json?page=2' },
+        links: {
+          next: `https://api${getRegionSubdomain()}.newrelic.com/v2/alerts_incidents.json?page=2`,
+        },
       })
       .mockResolvedValueOnce({
         status: 200,

--- a/test/tools/rest/apm.test.ts
+++ b/test/tools/rest/apm.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegionSubdomain } from '../../utils/region-helpers';
 
 const get = vi.fn();
 vi.mock('../../../src/client/rest-client', () => ({
@@ -18,7 +19,9 @@ describe('REST APM Tool', () => {
       .mockResolvedValueOnce({
         status: 200,
         data: [{ id: 1 }],
-        links: { next: 'https://api.newrelic.com/v2/applications.json?page=2' },
+        links: {
+          next: `https://api${getRegionSubdomain()}.newrelic.com/v2/applications.json?page=2`,
+        },
       })
       .mockResolvedValueOnce({ status: 200, data: [{ id: 2 }], links: {} });
     const tool = new RestApmTool();

--- a/test/tools/rest/deployments.test.ts
+++ b/test/tools/rest/deployments.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegionSubdomain } from '../../utils/region-helpers';
 
 // Mock REST client used by REST tools
 const post = vi.fn();
@@ -39,7 +40,9 @@ describe('REST Deployments Tool', () => {
       .mockResolvedValueOnce({
         status: 200,
         data: [{ id: 1 }],
-        links: { next: 'https://api.newrelic.com/v2/applications/1/deployments.json?page=2' },
+        links: {
+          next: `https://api${getRegionSubdomain()}.newrelic.com/v2/applications/1/deployments.json?page=2`,
+        },
       })
       .mockResolvedValueOnce({ status: 200, data: [{ id: 2 }], links: {} });
     const tool = new RestDeploymentsTool();

--- a/test/tools/rest/metrics.test.ts
+++ b/test/tools/rest/metrics.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRegionSubdomain } from '../../utils/region-helpers';
 
 const get = vi.fn();
 vi.mock('../../../src/client/rest-client', () => ({
@@ -18,7 +19,9 @@ describe('REST Metrics Tool', () => {
       .mockResolvedValueOnce({
         status: 200,
         data: [{ metric: 'CPU' }],
-        links: { next: 'https://api.newrelic.com/v2/x?page=2' },
+        links: {
+          next: `https://api${getRegionSubdomain()}.newrelic.com/v2/x?page=2`,
+        },
       })
       .mockResolvedValueOnce({ status: 200, data: [{ metric: 'Memory' }], links: {} });
     const tool = new RestMetricsTool();
@@ -51,7 +54,9 @@ describe('REST Metrics Tool', () => {
       .mockResolvedValueOnce({
         status: 200,
         data: [{ timeslices: [] }],
-        links: { next: 'https://api.newrelic.com/v2/x?page=2' },
+        links: {
+          next: `https://api${getRegionSubdomain()}.newrelic.com/v2/x?page=2`,
+        },
       })
       .mockResolvedValueOnce({ status: 200, data: [{ timeslices: [] }], links: {} });
     const tool = new RestMetricsTool();

--- a/test/utils/logging/newrelic-integration.ts
+++ b/test/utils/logging/newrelic-integration.ts
@@ -198,7 +198,7 @@ export const createNewRelicLogger = (serviceName: string = 'newrelic-mcp') => {
       new NewRelicTransport({
         apiKey,
         accountId,
-        region: (process.env.NEW_RELIC_REGION as 'US' | 'EU') || 'US',
+        region: getTestRegion(),
       }),
     ],
   });

--- a/test/utils/logging/newrelic-integration.ts
+++ b/test/utils/logging/newrelic-integration.ts
@@ -1,4 +1,5 @@
 import winston from 'winston';
+import { getTestRegion } from '../region-helpers';
 import { logger as winstonLogger } from './winston-logger';
 
 // New Relic log forwarding configuration
@@ -29,7 +30,7 @@ export class NewRelicTransport extends winston.transports.Stream {
     this.config = {
       batchSize: 100,
       flushInterval: 5000,
-      region: 'US',
+      region: getTestRegion(),
       ...config,
     };
 

--- a/test/utils/region-helpers.ts
+++ b/test/utils/region-helpers.ts
@@ -1,0 +1,19 @@
+/**
+ * Test utilities for region-specific testing
+ */
+
+/**
+ * Returns the region subdomain ('.eu' or '') based on NEW_RELIC_REGION env var
+ * Used for constructing region-aware API URLs in tests
+ */
+export function getRegionSubdomain(): string {
+  return process.env.NEW_RELIC_REGION?.toUpperCase() === 'EU' ? '.eu' : '';
+}
+
+/**
+ * Returns the test region ('US' | 'EU') based on NEW_RELIC_REGION env var
+ * Defaults to 'US' if not set
+ */
+export function getTestRegion(): 'US' | 'EU' {
+  return (process.env.NEW_RELIC_REGION?.toUpperCase() as 'US' | 'EU') || 'US';
+}

--- a/test/utils/region-helpers.ts
+++ b/test/utils/region-helpers.ts
@@ -15,5 +15,6 @@ export function getRegionSubdomain(): string {
  * Defaults to 'US' if not set
  */
 export function getTestRegion(): 'US' | 'EU' {
-  return (process.env.NEW_RELIC_REGION?.toUpperCase() as 'US' | 'EU') || 'US';
+  const region = process.env.NEW_RELIC_REGION?.toUpperCase();
+  return region === 'EU' ? 'EU' : 'US';
 }


### PR DESCRIPTION
### Summary

Adds regional support for New Relic NerdGraph API endpoints, enabling the MCP server to work with both US and EU data centers. The server now dynamically selects the correct API endpoint based on the `NEW_RELIC_REGION` environment variable, defaulting to US if not specified.

This change enables EU-based New Relic accounts to use the MCP server without encountering "not authorized for account region" errors. All NerdGraph operations (including NRQL queries, entity search, alerts, synthetics, etc.) now respect the regional configuration.

Additionally, test utilities were added into a shared `test/utils/region-helpers.ts` module.

### Type of change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor/chore/style/test

### Checklist

- [x] Tests added/updated
- [x] Lint/typecheck pass (`npm run lint && npm run typecheck`)
- [x] Updated docs/README as needed
- [x] Added entry to `CHANGELOG.md` under Unreleased

### Screenshots/recordings (if applicable)

N/A

### Breaking changes

None. This change is fully backward compatible:
- Defaults to US region if `NEW_RELIC_REGION` is not set
- Existing integrations continue to work without modification
- REST tools already had region support (no changes needed)
- Only NerdGraph operations were updated to support regions
- All configuration examples in README updated to include `NEW_RELIC_REGION: "US"` for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region-aware New Relic endpoints (US/EU) with NEW_RELIC_REGION support

* **Documentation**
  * README and examples updated to show NEW_RELIC_REGION usage and region defaults

* **Tests**
  * Tests updated to assert region-aware endpoint construction and pagination links

* **Chores**
  * Changelog bumped to v2.0.1 documenting regional support and related updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->